### PR TITLE
Set environment in test mode at initialization

### DIFF
--- a/src/pymgrid/Environments/Environment.py
+++ b/src/pymgrid/Environments/Environment.py
@@ -116,6 +116,8 @@ class Environment(gym.Env):
 #         return s_, reward, done, {}
 
     def reset(self, testing=False):
+        if "testing" in env_config:
+            testing = env_config["testing"]
         self.round = 1
         # Reseting microgrid
         self.mg.reset(testing=testing)


### PR DESCRIPTION
Allow to set the pymgrid wrapped env in testing mode at the initialization in addition to using reset(testing=True) to set it. This can be done by adding the key "testing" in the env_config dict given to the environment at init.