### PR TITLE
Documentation change. get_control_info() to print_control_info()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ By default, this command will let you generate 10 microgrids. The object m_gen w
 
 First, you can get the control information with this command:
 ```python
-m_gen.microgrids[0].get_control_info()
+m_gen.microgrids[0].print_control_info()
 
 ```
 


### PR DESCRIPTION
get_control_info() on Microgrid object does not work as mentioned in the documentation while print_control_info() works.
https://github.com/Total-RD/pymgrid/blob/master/src/pymgrid/Microgrid.py#L333
<img width="706" alt="Screen Shot 2022-02-20 at 9 31 51 AM" src="https://user-images.githubusercontent.com/10437812/154850658-650ea7ed-ec54-47df-bc64-da4ce6cd568a.png">
<img width="1035" alt="Screen Shot 2022-02-20 at 9 31 36 AM" src="https://user-images.githubusercontent.com/10437812/154850663-2b31fbea-68ac-46cc-958c-bc9bcf4377cc.png">


