### PR TITLE
Update forecasting to not include current step in forecast horizon

### DIFF
--- a/src/pymgrid/microgrid/convert/get_module.py
+++ b/src/pymgrid/microgrid/convert/get_module.py
@@ -24,13 +24,18 @@ def get_load_module(nonmodular, raise_errors):
     loss_load_cost = nonmodular.parameters['cost_loss_load'].item()
     return LoadModule(time_series=time_series,
                       loss_load_cost=loss_load_cost,
+                      forecaster='oracle',
+                      forecast_horizon=nonmodular.horizon,
                       raise_errors=raise_errors)
 
 
 def get_pv_module(nonmodular, raise_errors):
     time_series = nonmodular._pv_ts
     return RenewableModule(time_series=time_series,
-                           raise_errors=raise_errors)
+                           raise_errors=raise_errors,
+                           forecaster='oracle',
+                           forecast_horizon=nonmodular.horizon
+                           )
 
 
 def get_battery_module(nonmodular, raise_errors):
@@ -88,6 +93,8 @@ def get_grid_module(nonmodular, raise_errors):
                       max_export=max_export,
                       time_series_cost_co2=time_series_cost_co2,
                       cost_per_unit_co2=cost_per_unit_co2,
+                      forecaster='oracle',
+                      forecast_horizon=nonmodular.horizon,
                       raise_errors=raise_errors)
 
 

--- a/src/pymgrid/microgrid/modules/base/timeseries/base_timeseries_module.py
+++ b/src/pymgrid/microgrid/modules/base/timeseries/base_timeseries_module.py
@@ -17,7 +17,7 @@ class BaseTimeSeriesMicrogridModule(BaseMicrogridModule, ABC):
                  normalize_pos=...):
         self._time_series = self._set_time_series(time_series)
         self._min_obs, self._max_obs, self._min_act, self._max_act = self.get_bounds()
-        self.forecaster, self.forecast_horizon = get_forecaster(forecaster,
+        self.forecaster, self._forecast_horizon = get_forecaster(forecaster,
                                                                 forecast_horizon,
                                                                 self.time_series,
                                                                 increase_uncertainty=forecaster_increase_uncertainty)
@@ -79,6 +79,21 @@ class BaseTimeSeriesMicrogridModule(BaseMicrogridModule, ABC):
     @property
     def max_act(self):
         return self._max_act
+
+    @property
+    def forecast_horizon(self):
+        return self._forecast_horizon
+
+    @forecast_horizon.setter
+    def forecast_horizon(self, value):
+        if self.forecaster is not None:
+            self._forecast_horizon = value
+        else:
+            from warnings import warn
+            from pymgrid.microgrid.modules.base.timeseries.forecaster import OracleForecaster
+            warn("Setting forecast_horizon requires a non-null forecaster. Implementing OracleForecaster.")
+            self.forecaster = OracleForecaster()
+            self._forecast_horizon = value
 
     @property
     @abstractmethod

--- a/src/pymgrid/microgrid/modules/grid_module.py
+++ b/src/pymgrid/microgrid/modules/grid_module.py
@@ -9,6 +9,9 @@ class GridModule(BaseTimeSeriesMicrogridModule):
                  max_import,
                  max_export,
                  time_series_cost_co2,
+                 forecaster=None,
+                 forecast_horizon=24,
+                 forecaster_increase_uncertainty=False,
                  cost_per_unit_co2=0,
                  raise_errors=False):
 
@@ -18,6 +21,9 @@ class GridModule(BaseTimeSeriesMicrogridModule):
         self.name = ('grid', None)
         super().__init__(time_series_cost_co2,
                          raise_errors,
+                         forecaster=forecaster,
+                         forecast_horizon=forecast_horizon,
+                         forecaster_increase_uncertainty=forecaster_increase_uncertainty,
                          provided_energy_name='grid_import',
                          absorbed_energy_name='grid_export')
 

--- a/src/pymgrid/microgrid/modules/load_module.py
+++ b/src/pymgrid/microgrid/modules/load_module.py
@@ -5,9 +5,17 @@ import numpy as np
 class LoadModule(BaseTimeSeriesMicrogridModule):
     module_type = ('load', 'fixed')
 
-    def __init__(self, time_series, loss_load_cost, raise_errors=False):
+    def __init__(self, time_series,
+                 loss_load_cost,
+                 forecaster=None,
+                 forecast_horizon=24,
+                 forecaster_increase_uncertainty=False,
+                 raise_errors=False):
         super().__init__(time_series,
                          raise_errors=raise_errors,
+                         forecaster=forecaster,
+                         forecast_horizon=forecast_horizon,
+                         forecaster_increase_uncertainty=forecaster_increase_uncertainty,
                          provided_energy_name=None,
                          absorbed_energy_name='load_met')
 

--- a/tests/microgrid/modules/module_tests/test_renewable_module.py
+++ b/tests/microgrid/modules/module_tests/test_renewable_module.py
@@ -59,9 +59,9 @@ class TestRenewableModuleForecasting(TestCase):
         renewable_module = self.new_renewable_module()
         self.assertEqual(renewable_module.current_renewable, self.time_series[0])
         self.assertIsNotNone(renewable_module.forecast())
-        self.assertEqual(renewable_module.forecast(), self.time_series[:self.forecast_horizon].reshape((-1, 1)))
-        self.assertEqual(renewable_module.state, self.time_series[:self.forecast_horizon])
-        self.assertEqual(len(renewable_module.state_dict), self.forecast_horizon)
+        self.assertEqual(renewable_module.forecast(), self.time_series[1:1+self.forecast_horizon].reshape((-1, 1)))
+        self.assertEqual(renewable_module.state, self.time_series[:1+self.forecast_horizon])
+        self.assertEqual(len(renewable_module.state_dict), 1+self.forecast_horizon)
 
     def test_action_space(self):
         renewable_module = self.new_renewable_module()
@@ -76,8 +76,8 @@ class TestRenewableModuleForecasting(TestCase):
         normalized_obs_space = renewable_module.observation_spaces["normalized"]
         unnormalized_obs_space = renewable_module.observation_spaces["unnormalized"]
 
-        self.assertEqual(normalized_obs_space, Box(low=0, high=1, shape=(1,)))
-        self.assertEqual(unnormalized_obs_space, Box(low=0, high=self.time_series.max(), shape=(1,)))
+        self.assertEqual(normalized_obs_space, Box(low=0, high=1, shape=(1+renewable_module.forecast_horizon,)))
+        self.assertEqual(unnormalized_obs_space, Box(low=0, high=self.time_series.max(), shape=(1+renewable_module.forecast_horizon,)))
 
     def test_step(self):
         renewable_module = self.new_renewable_module()
@@ -87,7 +87,7 @@ class TestRenewableModuleForecasting(TestCase):
         action = renewable_module.to_normalized(unnormalized_action, act=True)
         obs, reward, done, info = renewable_module.step(action)
         obs = renewable_module.from_normalized(obs, obs=True)
-        self.assertEqual(obs, self.time_series[1:self.forecast_horizon+1])
+        self.assertEqual(obs, self.time_series[1:self.forecast_horizon+2])
         self.assertEqual(reward, 0)
         self.assertFalse(done)
         self.assertEqual(info["provided_energy"], unnormalized_action)


### PR DESCRIPTION
Also update parameters of subclasses of `BaseTimeSeriesMicrogridModule` to include forecasting params.