### PR TITLE
better ModuleSpace __repr__

### DIFF
--- a/src/pymgrid/utils/space.py
+++ b/src/pymgrid/utils/space.py
@@ -45,7 +45,7 @@ class ModuleSpace(Space):
         raise KeyError(item)
 
     def __repr__(self):
-        return f'ModuleSpace{repr(self._unnormalized)[3:]}'
+        return f'ModuleSpace{repr(self._unnormalized).replace("Box", "")}'
 
     def __eq__(self, other):
         if type(self) != type(other):


### PR DESCRIPTION


<!-- readthedocs-preview pymgrid start -->
----
:books: Documentation preview :books:: https://pymgrid--177.org.readthedocs.build/en/177/

<!-- readthedocs-preview pymgrid end -->