### PR TITLE
ModuleContainer refactoring

### DIFF
--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -184,10 +184,12 @@ class BaseMicrogridEnv(Microgrid, Env):
 
         """
         try:
-            return cls(microgrid.module_tuples(), add_unbalanced_module=False)
+            modules = microgrid.modules
         except AttributeError:
             assert isinstance(microgrid, NonModularMicrogrid)
             return cls.from_nonmodular(microgrid)
+        else:
+            return cls(modules.to_tuples(), add_unbalanced_module=False)
 
     @classmethod
     def from_nonmodular(cls, nonmodular):

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -419,7 +419,7 @@ class Microgrid(yaml.YAMLObject):
 
         """
         horizons = []
-        for module in self.iterlist():
+        for module in self._modules.iterlist():
             try:
                 horizons.append(module.forecast_horizon)
             except AttributeError:

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -543,7 +543,7 @@ class Microgrid(yaml.YAMLObject):
             The list of modules
 
         """
-        return self._modules.module_list()
+        return self._modules.to_list()
 
     @property
     def n_modules(self):

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -285,7 +285,7 @@ class Microgrid(yaml.YAMLObject):
 
         """
 
-        module_iterator = self._modules.module_dict() if sample_flex_modules else self._modules.controllable.module_dict()
+        module_iterator = self._modules.to_dict() if sample_flex_modules else self._modules.controllable.to_dict()
         return {module_name: [module.sample_action(strict_bound=strict_bound) for module in module_list]
                 for module_name, module_list in module_iterator.items()
                 if module_list[0].action_space.shape[0]}
@@ -309,7 +309,7 @@ class Microgrid(yaml.YAMLObject):
             Empty action.
 
         """
-        module_iterator = self._modules.module_dict() if sample_flex_modules else self._modules.controllable.module_dict()
+        module_iterator = self._modules.to_dict() if sample_flex_modules else self._modules.controllable.to_dict()
 
         return {module_name: [None]*len(module_list) for module_name, module_list in module_iterator.items()
                 if module_list[0].action_space.shape[0]}

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -625,7 +625,7 @@ class Microgrid(yaml.YAMLObject):
         """
         :meta private:
         """
-        data = {"modules": self._modules.module_tuples(),
+        data = {"modules": self._modules.to_tuples(),
                 "balance_log": self._balance_logger.serialize()}
         return dump_data(data, dumper_stream, self.yaml_tag)
 
@@ -702,7 +702,7 @@ class Microgrid(yaml.YAMLObject):
             return cls.load(f)
 
     def __getnewargs__(self):
-        return (self.module_tuples(), )
+        return (self.modules.to_tuples(), )
 
     def __len__(self):
         """

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -212,8 +212,9 @@ def get_subcontainers(modules):
         try:
             module_names[module_name] = (fixed_flex_controllable, source_sink_both)
         except KeyError:
-            raise NameError(f'Attempted to add module {module_name} of type {(fixed_flex_controllable, source_sink_both)}, '
-                            f'but there is an identically named module of type {module_names[module_name]}.')
+            raise NameError(
+                f'Attempted to add module {module_name} of type {(fixed_flex_controllable, source_sink_both)}, '
+                f'but there is an identically named module of type {module_names[module_name]}.')
 
         try:
             d[source_sink_both][module_name].append(module)

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -30,7 +30,7 @@ class Container(UserDict):
             d.update(raw_container)
         return d
 
-    def module_tuples(self):
+    def to_tuples(self):
         l = []
         for name, modules in self.iterdict():
             tups = list(zip([name] * len(modules), modules))

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -19,18 +19,45 @@ class Container(UserDict):
         return self
 
     def to_list(self):
+        """
+        Get the modules as a list.
+
+        Returns
+        -------
+        l : list of modules
+            List of modules
+
+        """
         l = []
         for _, raw_container in self.containers.items():
             l.extend(raw_container.to_list())
         return l
 
     def to_dict(self):
+        """
+        Get the modules as a dictionary.
+
+        Returns
+        -------
+        d : dict[str, module]
+            Dictionary with module names as keys, modules as tuples.
+
+        """
         d = dict()
         for k, raw_container in self.containers.items():
             d.update(raw_container)
         return d
 
     def to_tuples(self):
+        """
+        Get the modules in (name, module) pairs.
+
+        Returns
+        -------
+        tups : list of tuples: (name, module)
+            Module names and modules.
+
+        """
         l = []
         for name, modules in self.iterdict():
             tups = list(zip([name] * len(modules), modules))
@@ -38,14 +65,35 @@ class Container(UserDict):
         return l
 
     def iterlist(self):
+        """
+        Iterable of the container's modules as a list.
+
+        Returns
+        -------
+        iter : generator
+            Iterator of modules.
+
+        """
         for module in self.to_list():
             yield module
 
     def iterdict(self):
+        """
+        Iterable of the container's modules as a dict.
+
+        Returns
+        -------
+        iter : generator
+            Iterator of (name, module) pairs.
+
+        """
         for name, modules in self.to_dict().items():
             yield name, modules
 
     def dir_additions(self):
+        """
+        :meta private:
+        """
         additions = set(self.keys())
         for x in self.values():
             try:
@@ -126,7 +174,6 @@ class ModuleContainer(Container):
         Each level can be iterated on, both by calling .items() or by iterating through the modules directly with .iterlist()
         For example, container.sinks.iterlist() returns an iterator of all the sinks, without their names.
 
-
     """
     def __init__(self, modules):
         """
@@ -170,20 +217,37 @@ class ModuleContainer(Container):
 
 class ModuleList(UserList):
     def item(self):
+        """
+        Get the value of a singleton list.
+
+        Returns
+        -------
+        module : BaseMicrogridModule
+            Item in a singleton list.
+
+        Raises
+        ------
+        ValueError :
+            If there is more than one item in the list.
+
+        """
         if len(self) != 1:
             raise ValueError("Can only convert a ModuleList of length one to a scalar")
         return self[0]
 
     def to_list(self):
+        """
+        :meta private:
+
+        Function to be compatible with Container API.
+
+        """
         return self
 
 
 def get_subcontainers(modules):
     """
-
-    :return: List[Tuple]
-        3-element tuples of (fixed_flex_controllable, source_or_sink, container)
-
+    :meta private:
     """
     source_sink_keys = ('sources', 'sinks', 'source_and_sinks')
     fixed = {k: dict() for k in source_sink_keys}

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -169,6 +169,16 @@ class ModuleContainer(Container):
         return self._containers
 
 
+class ModuleList(UserList):
+    def item(self):
+        if len(self) != 1:
+            raise ValueError("Can only convert a ModuleList of length one to a scalar")
+        return self[0]
+
+    def module_list(self):
+        return self
+
+
 def get_subcontainers(modules):
     """
 
@@ -231,13 +241,3 @@ def get_subcontainers(modules):
                   for source_sink_both in source_sink_keys}
 
     return containers
-
-
-class ModuleList(UserList):
-    def item(self):
-        if len(self) != 1:
-            raise ValueError("Can only convert a ModuleList of length one to a scalar")
-        return self[0]
-
-    def module_list(self):
-        return self

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -82,7 +82,6 @@ class Container(UserDict):
         except TypeError:
             return super().__repr__()
 
-
     def __dir__(self):
         rv = set(super().__dir__())
         rv = rv | self.dir_additions()

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -24,7 +24,7 @@ class Container(UserDict):
             l.extend(raw_container.to_list())
         return l
 
-    def module_dict(self):
+    def to_dict(self):
         d = dict()
         for k, raw_container in self.containers.items():
             d.update(raw_container)
@@ -42,7 +42,7 @@ class Container(UserDict):
             yield module
 
     def iterdict(self):
-        for name, modules in self.module_dict().items():
+        for name, modules in self.to_dict().items():
             yield name, modules
 
     def dir_additions(self):
@@ -61,7 +61,7 @@ class Container(UserDict):
             return self.data[item]
         except KeyError:
             try:
-                return self.module_dict()[item]
+                return self.to_dict()[item]
             except KeyError:
                 raise KeyError(item)
 
@@ -78,7 +78,7 @@ class Container(UserDict):
 
     def __repr__(self):
         try:
-            return json.dumps(self.module_dict(), indent=2, default=str)
+            return json.dumps(self.to_dict(), indent=2, default=str)
         except TypeError:
             return super().__repr__()
 

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -238,3 +238,6 @@ class ModuleList(UserList):
         if len(self) != 1:
             raise ValueError("Can only convert a ModuleList of length one to a scalar")
         return self[0]
+
+    def module_list(self):
+        return self

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -18,10 +18,10 @@ class Container(UserDict):
         """
         return self
 
-    def module_list(self):
+    def to_list(self):
         l = []
         for _, raw_container in self.containers.items():
-            l.extend(raw_container.module_list())
+            l.extend(raw_container.to_list())
         return l
 
     def module_dict(self):
@@ -38,7 +38,7 @@ class Container(UserDict):
         return l
 
     def iterlist(self):
-        for module in self.module_list():
+        for module in self.to_list():
             yield module
 
     def iterdict(self):
@@ -175,7 +175,7 @@ class ModuleList(UserList):
             raise ValueError("Can only convert a ModuleList of length one to a scalar")
         return self[0]
 
-    def module_list(self):
+    def to_list(self):
         return self
 
 

--- a/tests/envs/test_discrete.py
+++ b/tests/envs/test_discrete.py
@@ -13,20 +13,20 @@ class TestDiscreteEnv(TestCase):
         env = DiscreteMicrogridEnv(microgrid)
 
         self.assertEqual(env.modules, microgrid.modules)
-        self.assertIsNot(env.modules.module_tuples(), microgrid.modules.module_tuples())
+        self.assertIsNot(env.modules.to_tuples(), microgrid.modules.to_tuples())
 
-        n_obs = sum([x.observation_spaces['normalized'].shape[0] for x in microgrid.modules.module_list()])
+        n_obs = sum([x.observation_spaces['normalized'].shape[0] for x in microgrid.modules.to_list()])
 
         self.assertEqual(env.observation_space.shape, (n_obs,))
 
     def test_init_from_modules(self):
         microgrid = get_modular_microgrid()
-        env = DiscreteMicrogridEnv(microgrid.modules.module_tuples(), add_unbalanced_module=False)
+        env = DiscreteMicrogridEnv(microgrid.modules.to_tuples(), add_unbalanced_module=False)
 
         self.assertEqual(env.modules, microgrid.modules)
-        self.assertIsNot(env.modules.module_tuples(), microgrid.modules.module_tuples())
+        self.assertIsNot(env.modules.to_tuples(), microgrid.modules.to_tuples())
 
-        n_obs = sum([x.observation_spaces['normalized'].shape[0] for x in microgrid.modules.module_list()])
+        n_obs = sum([x.observation_spaces['normalized'].shape[0] for x in microgrid.modules.to_list()])
 
         self.assertEqual(env.observation_space.shape, (n_obs,))
 


### PR DESCRIPTION
* Add Container as replacement to _ModulePointer and _ModuleSubContainer. Also acts as superclass to ModuleContainer
* Rename `module_<stuff>` to `to_<stuff>`
* Docs

<!-- readthedocs-preview pymgrid start -->
----
:books: Documentation preview :books:: https://pymgrid--183.org.readthedocs.build/en/183/

<!-- readthedocs-preview pymgrid end -->