### PR TITLE
step attrs

### DIFF
--- a/src/pymgrid/algos/mpc/mpc.py
+++ b/src/pymgrid/algos/mpc/mpc.py
@@ -541,7 +541,10 @@ class ModelPredictiveControl:
                                          iteration=i,
                                          total_iterations=num_iter)
 
-            self.microgrid.run(control, normalized=False)
+            _, _, done, _ = self.microgrid.run(control, normalized=False)
+
+            if done:
+                break
 
         return self.microgrid.get_log()
 

--- a/src/pymgrid/algos/mpc/mpc.py
+++ b/src/pymgrid/algos/mpc/mpc.py
@@ -533,12 +533,7 @@ class ModelPredictiveControl:
 
     def _run_mpc_on_modular(self, forecast_steps=None, verbose=False):
 
-        if forecast_steps is None:
-            num_iter = len(self.microgrid) - self.horizon
-        else:
-            assert forecast_steps <= len(self.microgrid) - self.horizon, 'forecast steps can\'t look past horizon'
-            num_iter = forecast_steps
-
+        num_iter = self._get_num_iter(forecast_steps)
         self.microgrid.reset()
 
         for i in tqdm(range(num_iter), desc="MPC Progress", disable=(not verbose)):
@@ -549,6 +544,17 @@ class ModelPredictiveControl:
             self.microgrid.run(control, normalized=False)
 
         return self.microgrid.get_log()
+
+
+    def _get_num_iter(self, forecast_steps=None):
+        if forecast_steps is not None:
+            assert forecast_steps <= len(self.microgrid), 'forecast steps cannot be longer than data length.'
+            return forecast_steps
+
+        elif not self.is_modular:
+            return len(self.microgrid) - self.horizon
+
+        return self.microgrid.final_step - self.microgrid.initial_step
 
     def _run_mpc_on_sample(self, sample, forecast_steps=None, verbose=False):
         """

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -546,6 +546,18 @@ class Microgrid(yaml.YAMLObject):
             raise AttributeError(f'No module has attribute {attr_name}.')
 
     @property
+    def current_step(self):
+        return self._modules.get_attrs('current_step', unique=True).item()
+
+    @property
+    def initial_step(self):
+        return self.modules.get_attrs('initial_step', unique=True).item()
+
+    @property
+    def final_step(self):
+        return self.modules.get_attrs('final_step', unique=True).item()
+
+    @property
     def modules(self):
         """
         View of the module container.

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -547,14 +547,40 @@ class Microgrid(yaml.YAMLObject):
 
     @property
     def current_step(self):
+        """
+        Current step of underlying modules.
+
+        Returns
+        -------
+        current_step : int
+            Current step.
+        """
         return self._modules.get_attrs('current_step', unique=True).item()
 
     @property
     def initial_step(self):
+        """
+        Initial step at which to start underlying timeseries data.
+
+        The step to which :attr:`.current_step` is reset to when calling :meth:`.reset`.
+
+        Returns
+        -------
+        initial_step : int
+            Initial step.
+        """
         return self.modules.get_attrs('initial_step', unique=True).item()
 
     @property
     def final_step(self):
+        """
+        Final step of underlying timeseries data.
+
+        Returns
+        -------
+        final_step : int
+            Final step.
+        """
         return self.modules.get_attrs('final_step', unique=True).item()
 
     @property

--- a/src/pymgrid/microgrid/microgrid.py
+++ b/src/pymgrid/microgrid/microgrid.py
@@ -404,7 +404,7 @@ class Microgrid(yaml.YAMLObject):
 
         col_names = ['module_name', 'module_number', 'field']
 
-        df = pd.DataFrame(_log_dict)
+        df = pd.DataFrame(_log_dict, index=pd.RangeIndex(start=self.initial_step, stop=self.current_step))
         df.columns = pd.MultiIndex.from_tuples(df.columns.to_list(), names=col_names)
 
         if drop_singleton_key:

--- a/src/pymgrid/modules/base/base_module.py
+++ b/src/pymgrid/modules/base/base_module.py
@@ -292,7 +292,8 @@ class BaseMicrogridModule(yaml.YAMLObject):
     def _update_step(self, reset=False):
         if reset:
             self._current_step = self.initial_step
-        self._current_step += 1
+        else:
+            self._current_step += 1
 
     @abstractmethod
     def update(self, external_energy_change, as_source=False, as_sink=False):

--- a/tests/microgrid/test_microgrid.py
+++ b/tests/microgrid/test_microgrid.py
@@ -69,6 +69,26 @@ class TestMicrogrid(TestCase):
 
                     self.assertTrue(empty_action_space != has_corresponding_action)  # XOR
 
+    def test_current_step(self):
+        microgrid = get_modular_microgrid()
+
+        self.assertEqual(microgrid.current_step, 0)
+
+        for j in range(4):
+            with self.subTest(step=j):
+                microgrid.run(microgrid.sample_action())
+                self.assertEqual(microgrid.current_step, j+1)
+
+    def test_current_step_after_reset(self):
+        microgrid = get_modular_microgrid()
+        self.assertEqual(microgrid.current_step, 0)
+
+        microgrid.run(microgrid.sample_action())
+        self.assertEqual(microgrid.current_step, 1)
+
+        microgrid.reset()
+        self.assertEqual(microgrid.current_step, 0)
+
     def test_set_module_attr_forecast_horizon(self):
         forecast_horizon = 50
 


### PR DESCRIPTION
* Add `initial_step`, `current_step`, `final_step` attributes to microgrid
* Add tests
* Bug fix with `current_step` being set to 1 on reset
* Set index of logs to be range b/w `initial_step` and `current_step`

<!-- readthedocs-preview pymgrid start -->
----
:books: Documentation preview :books:: https://pymgrid--224.org.readthedocs.build/en/224/

<!-- readthedocs-preview pymgrid end -->