### PR TITLE
speedups

### DIFF
--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -6,6 +6,9 @@ from pymgrid.modules.base import BaseMicrogridModule
 
 
 class Container(UserDict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dir_additions = self.dir_additions()
 
     @property
     def containers(self):
@@ -191,7 +194,7 @@ class Container(UserDict):
         additions = set(self.keys())
         for x in self.values():
             try:
-                additions.update(x.dir_additions())
+                additions.update(x.dir_additions)
             except AttributeError:
                 pass
         return additions
@@ -226,11 +229,11 @@ class Container(UserDict):
 
     def __dir__(self):
         rv = set(super().__dir__())
-        rv = rv | self.dir_additions()
+        rv = rv | self.dir_additions
         return sorted(rv)
 
     def __contains__(self, item):
-        return item in self.data.keys() or item in self.dir_additions()
+        return item in self.data.keys() or item in self.dir_additions
 
 
 class ModuleContainer(Container):

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -98,10 +98,10 @@ class Container(UserDict):
         """
         Get module attributes as a dictionary or pandas object.
 
-        If `unique`, checks that the value is unique for all modules and returns only the unique value.
+        If ``unique``, checks that the value is unique for all modules and returns only the unique value.
         Otherwise, returns the values for all modules.
 
-        If `as_pandas`, returns either a pd.Series (if `unique`) or pd.DataFrame of attributes.
+        If ``as_pandas``, returns either a pd.Series (if ``unique``) or pd.DataFrame of attributes.
 
         Parameters
         ----------
@@ -110,15 +110,15 @@ class Container(UserDict):
 
         unique : bool, default False
             Whether to check for and return a single, unique value for an attribute.
-            If different modules have different values, a `ValueError` will be raised.
+            If different modules have different values, a ``ValueError`` will be raised.
 
         as_pandas : bool, default True
             Whether to return either a pd.Series or pd.DataFrame.
-            If True, the return value will be a pd.Series if `unique` and a pd.DataFrame otherwise.
+            If True, the return value will be a pd.Series if ``unique`` and a pd.DataFrame otherwise.
             If False, returns a dict.
 
         .. note::
-            If only some modules have a particular attribute, `get_attrs` will not raise an error.
+            If only some modules have a particular attribute, ``get_attrs`` will not raise an error.
 
             If ``unique``, the unique value of the modules containing the value will be returned.
             Otherwise, ``NotImplemented`` will fill in missing values.
@@ -126,15 +126,15 @@ class Container(UserDict):
         Returns
         -------
         d : dict or pd.DataFrame or pd.Series
-            * Returns dict if `as_pandas` is False.
+            * Returns dict if ``as_pandas`` is False.
 
-            * Otherwise, returns a pd.Series if `unique` and a pd.DataFrame if not.
+            * Otherwise, returns a pd.Series if ``unique`` and a pd.DataFrame otherwise.
 
         Raises
         ------
         ValueError
-            * If `attrs` is empty, or
-            * `unique` is True and non-unique values are found.
+            * If ``attrs`` is empty, or
+            * ``unique`` is True and non-unique values are found.
 
         AttributeError
             If no module has the particular attribute.

--- a/src/pymgrid/modules/module_container.py
+++ b/src/pymgrid/modules/module_container.py
@@ -139,6 +139,9 @@ class Container(UserDict):
         AttributeError
             If no module has the particular attribute.
 
+            .. warning::
+            This check is not performed if both ``unique`` and ``as_pandas`` are False.
+
         """
         if not attrs:
             raise ValueError('Missing attrs to get.')
@@ -149,6 +152,9 @@ class Container(UserDict):
                 name: [{attr: getattr(module, attr, NotImplemented) for attr in attrs} for module in module_list]
                 for name, module_list in raw_container.items()
             })
+
+        if not (unique or as_pandas):
+            return d
 
         d_df = pd.DataFrame({(name, num): subdict for name, module_list in d.items()
                             for num, subdict in enumerate(module_list)}).T


### PR DESCRIPTION
* cache dir additions in `ModuleContainer`
* skip defining dataframe definitions in `ModuleContainer.get_attrs` if not returning unique or dataframe values

<!-- readthedocs-preview pymgrid start -->
----
:books: Documentation preview :books:: https://pymgrid--228.org.readthedocs.build/en/228/

<!-- readthedocs-preview pymgrid end -->