### PR TITLE
correct overgeneration consumption for controllable modules

### DIFF
--- a/src/pymgrid/algos/priority_list/priority_list.py
+++ b/src/pymgrid/algos/priority_list/priority_list.py
@@ -102,7 +102,7 @@ class PriorityListAlgo:
         if module_to_deploy.is_sink:
             assert module_max_consumption >= 0
 
-            if -1 * remaining_load < module_to_deploy.max_consumption:
+            if -1 * remaining_load > module_to_deploy.max_consumption:
                 # Can't consume it all
                 module_consumption = -1.0 * module_to_deploy.max_consumption
             else:


### PR DESCRIPTION
Hi,
while working with your project and analyzing your code, I stumbled accross an misscalculation if the provided energy exceeds the load. I think you have misplaced the relational operator here. First tests show that the miscalculation is resolved with this change.
(-1 * remaining_load) should be greate than (max_consumption) to exceed the modules consumption

Best regards ;)

<!-- readthedocs-preview pymgrid start -->
----
:books: Documentation preview :books:: https://pymgrid--231.org.readthedocs.build/en/231/

<!-- readthedocs-preview pymgrid end -->