### PR TITLE
obs keys in envs

### DIFF
--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -166,7 +166,7 @@ class BaseMicrogridEnv(Microgrid, Env):
 
         obs, reward, done, info = self.run(action, normalized=normalized)
         if self.observation_keys:
-            obs = self.state_series.loc[pd.IndexSlice[:, :, self.observation_keys]]
+            obs = self.state_series(normalized=True).loc[pd.IndexSlice[:, :, self.observation_keys]]
 
         if self._flat_spaces:
             obs = flatten(self._nested_observation_space, obs)

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -79,7 +79,8 @@ class BaseMicrogridEnv(Microgrid, Env):
                  overgeneration_cost=2,
                  reward_shaping_func=None,
                  trajectory_func=None,
-                 flat_spaces=True
+                 flat_spaces=True,
+                 observation_keys=None
                  ):
 
         super().__init__(modules,
@@ -90,8 +91,25 @@ class BaseMicrogridEnv(Microgrid, Env):
                          trajectory_func=trajectory_func)
 
         self._flat_spaces = flat_spaces
+        self.observation_keys = self._validate_observation_keys(observation_keys)
+
         self.action_space = self._get_action_space()
         self.observation_space, self._nested_observation_space = self._get_observation_space()
+
+    def _validate_observation_keys(self, keys):
+        if keys is None:
+            return None
+
+        if isinstance(keys, str):
+            keys = [keys]
+
+        possible_keys = self.state_series.index.get_level_values(-1).unique()
+        bad_keys = [key for key in keys if key not in possible_keys]
+
+        if bad_keys:
+            raise NameError(f'Keys {bad_keys} not found in state.')
+
+        return keys
 
     @abstractmethod
     def _get_action_space(self, remove_redundant_actions=False):

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -198,8 +198,14 @@ class BaseMicrogridEnv(Microgrid, Env):
         if self.observation_keys:
             obs = self.state_series(normalized=True).loc[pd.IndexSlice[:, :, self.observation_keys]]
 
-        if self._flat_spaces:
+            if self._flat_spaces:
+                obs = obs.values
+            else:
+                obs = obs.to_frame().unstack(level=1).T.droplevel(level=1, axis=1).to_dict(orient='list')
+
+        elif self._flat_spaces:
             obs = flatten(self._nested_observation_space, obs)
+
         return obs, reward, done, info
 
     def render(self, mode="human"):

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from gym import Env
 from gym.spaces import Dict, Tuple, flatten_space, flatten
 from abc import abstractmethod
@@ -163,6 +165,9 @@ class BaseMicrogridEnv(Microgrid, Env):
         """
 
         obs, reward, done, info = self.run(action, normalized=normalized)
+        if self.observation_keys:
+            obs = self.state_series.loc[pd.IndexSlice[:, :, self.observation_keys]]
+
         if self._flat_spaces:
             obs = flatten(self._nested_observation_space, obs)
         return obs, reward, done, info

--- a/src/pymgrid/envs/base/base.py
+++ b/src/pymgrid/envs/base/base.py
@@ -105,7 +105,7 @@ class BaseMicrogridEnv(Microgrid, Env):
         if isinstance(keys, str):
             keys = [keys]
 
-        possible_keys = self.state_series.index.get_level_values(-1).unique()
+        possible_keys = self.state_series().index.get_level_values(-1).unique()
         bad_keys = [key for key in keys if key not in possible_keys]
 
         if bad_keys:

--- a/src/pymgrid/envs/discrete/discrete.py
+++ b/src/pymgrid/envs/discrete/discrete.py
@@ -43,6 +43,7 @@ class DiscreteMicrogridEnv(BaseMicrogridEnv, PriorityListAlgo):
                  reward_shaping_func=None,
                  trajectory_func=None,
                  flat_spaces=True,
+                 observation_keys=None,
                  remove_redundant_gensets=True
                  ):
         super().__init__(modules,
@@ -51,7 +52,8 @@ class DiscreteMicrogridEnv(BaseMicrogridEnv, PriorityListAlgo):
                          overgeneration_cost=overgeneration_cost,
                          reward_shaping_func=reward_shaping_func,
                          trajectory_func=trajectory_func,
-                         flat_spaces=flat_spaces)
+                         flat_spaces=flat_spaces,
+                         observation_keys=observation_keys)
 
         self.action_space, self.actions_list = self._get_action_space(remove_redundant_gensets)
 

--- a/tests/envs/test_discrete.py
+++ b/tests/envs/test_discrete.py
@@ -79,6 +79,15 @@ class TestDiscreteEnvScenario(TestCase):
         n_actions = factorial(n_action_modules) * (2 ** genset_modules)
         self.assertEqual(env.action_space.n, n_actions)
 
+    def test_simple_observation_keys(self):
+        keys_in_all_scenarios = ['load_current', 'renewable_current']
+
+        env = DiscreteMicrogridEnv.from_scenario(microgrid_number=self.microgrid_number,
+                                                 observation_keys=keys_in_all_scenarios)
+
+        env.step(env.action_space.sample())
+        print(env.log)
+
 
 class TestDiscreteEnvScenario1(TestDiscreteEnvScenario):
     microgrid_number = 1

--- a/tests/envs/test_discrete.py
+++ b/tests/envs/test_discrete.py
@@ -85,8 +85,14 @@ class TestDiscreteEnvScenario(TestCase):
         env = DiscreteMicrogridEnv.from_scenario(microgrid_number=self.microgrid_number,
                                                  observation_keys=keys_in_all_scenarios)
 
-        env.step(env.action_space.sample())
-        print(env.log)
+        obs, _, _, _ = env.step(env.action_space.sample())
+
+        expected_obs = [
+            env.modules['load'].item().state_dict(normalized=True)['load_current'],
+            env.modules['pv'].item().state_dict(normalized=True)['renewable_current']
+        ]
+
+        self.assertEqual(obs.tolist(), expected_obs)
 
 
 class TestDiscreteEnvScenario1(TestDiscreteEnvScenario):


### PR DESCRIPTION
allow usage of only some observation components

<!-- readthedocs-preview pymgrid start -->
----
:books: Documentation preview :books:: https://pymgrid--247.org.readthedocs.build/en/247/

<!-- readthedocs-preview pymgrid end -->